### PR TITLE
Remove unused ping import

### DIFF
--- a/src/machines.py
+++ b/src/machines.py
@@ -21,7 +21,6 @@ if use_compression:
 import prefs
 import util
 import transfers
-import ping
 from ops import SendOp, ReceiveOp
 from util import TransferDirection, OpStatus, OpCommand, RemoteStatus
 


### PR DESCRIPTION
I'm unsure if there is a larger goal in mind for `ping` but I wanted to offer this PR in case the solution was the seemingly obvious one.

Without this, the following error is encountered when running:

```
Traceback (most recent call last):
  File "/usr/lib/warp/warp.py", line 19, in <module>
    import machines
  File "/usr/lib/warp/machines.py", line 24, in <module>
    import ping
ModuleNotFoundError: No module named 'ping'
```