### PR TITLE
file-chooser: Set a parent for the dialog

### DIFF
--- a/src/util.py
+++ b/src/util.py
@@ -58,9 +58,9 @@ OpCommand = IntEnum('OpCommand', 'START_TRANSFER \
 
 # A normal GtkFileChooserDialog only lets you pick folders OR files, not
 # both in the same dialog.  This does.
-def create_file_and_folder_picker(parent=None):
+def create_file_and_folder_picker(dialog_parent=None):
     window = Gtk.Dialog(title=_("Select file(s) to send"),
-                        parent=None,
+                        parent=dialog_parent,
                         default_width=750,
                         default_height=500)
     window.add_buttons(_("Cancel"), Gtk.ResponseType.CANCEL,

--- a/src/warpinator.py
+++ b/src/warpinator.py
@@ -616,7 +616,7 @@ class WarpWindow(GObject.Object):
         self.current_selected_remote_machine.send_files([uri])
 
     def open_file_picker(self, button, data=None):
-        dialog = util.create_file_and_folder_picker()
+        dialog = util.create_file_and_folder_picker(self.window)
 
         res = dialog.run()
 
@@ -1241,7 +1241,7 @@ class WarpApplication(Gtk.Application):
         self.send_status_icon_selection_to_machine(uri, remote_machine)
 
     def open_file_picker(self, button, remote_machine=None):
-        dialog = util.create_file_and_folder_picker()
+        dialog = util.create_file_and_folder_picker(self.window)
 
         res = dialog.run()
 


### PR DESCRIPTION
This just stops the GtkWarning for showing dialogs with no parents.