### PR TITLE
main-window.ui: Set a list box selection property to None

### DIFF
--- a/resources/main-window.ui
+++ b/resources/main-window.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.2 -->
+<!-- Generated with glade 3.22.1 -->
 <interface domain="warpinator">
   <requires lib="gtk+" version="3.20"/>
   <requires lib="xapp" version="0.0"/>
@@ -546,6 +546,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="vexpand">True</property>
+                                <property name="selection_mode">none</property>
                               </object>
                             </child>
                           </object>


### PR DESCRIPTION
There is currently no reason to allow selecting the row. Setting this also
retains the hover effect when mousing over a row.